### PR TITLE
Add skip slicer functionality

### DIFF
--- a/src/persistState.js
+++ b/src/persistState.js
@@ -58,6 +58,10 @@ export default function persistState(paths, config) {
       const state = store.getState()
       const subset = slicerFn(state)
 
+      if (subset === undefined) {
+        return
+      }
+
       try {
         localStorage.setItem(key, serialize(subset))
       } catch (e) {


### PR DESCRIPTION
In some cases we need to return undefined from custom slicer function (skip slicer)
In this case no need to call localStorage.setItem